### PR TITLE
Add Temporal Pagerank

### DIFF
--- a/docs/src/reference/the-traversal.asciidoc
+++ b/docs/src/reference/the-traversal.asciidoc
@@ -3409,6 +3409,49 @@ g.V().hasLabel('person').
 link:++https://tinkerpop.apache.org/javadocs/x.y.z/core/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.html#pageRank()++[`pageRank()`],
 link:++https://tinkerpop.apache.org/javadocs/x.y.z/core/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.html#pageRank(double)++[`pageRank(double)`]
 
+[[temporal-pagerank-step]]
+=== Temporal PageRank Step
+
+The `temporalPageRank()`-step (*map*/*sideEffect*) calculates <<pagerank-step,`pageRank()`>> over the subgraph whose
+vertices and edges intersect the supplied query window. The window is normalized with `lifetime()` semantics before the
+step builds its temporal filters, so bounded and open-ended queries use the same inclusive boundary handling as the
+rest of the temporal model.
+
+IMPORTANT: The `temporalPageRank()`-step is a `VertexComputing`-step and as such, can only be used against a graph
+that supports `GraphComputer` (OLAP).
+
+A query `startTime` is required. Elements without temporal properties are treated as always active, which allows
+`temporalPageRank()` to be mixed with non-temporal data while still excluding vertices and edges that fall completely
+outside the requested window.
+
+[gremlin-groovy]
+----
+g = traversal().withEmbedded(graph).withComputer()
+g.V().hasLabel('person').
+  temporalPageRank("2020-01-01", "2020-12-31").
+    with(PageRank.edges, __.outE('knows')).
+    with(PageRank.propertyName, 'windowRank').
+    with(PageRank.times, 30).
+  order().by('windowRank', desc).
+  elementMap('name', 'windowRank')
+
+g.V().temporalPageRank(0.90d, "2021-01-01").
+  with(PageRank.propertyName, 'recentRank').
+  values('recentRank')
+----
+
+As with `pageRank()`, the `with()` modulator accepts configuration keys from `PageRank`. Custom `PageRank.edges`
+traversals are intersected with the active temporal window before the `PageRankVertexProgram` is generated, so the
+temporal filter remains in effect regardless of the order in which `with(PageRank.edges, ...)`,
+`with(PageRank.propertyName, ...)`, and `with(PageRank.times, ...)` are configured.
+
+*Additional References*
+
+link:++https://tinkerpop.apache.org/javadocs/x.y.z/core/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.html#temporalPageRank(java.lang.String,java.lang.String)++[`temporalPageRank(String,String)`],
+link:++https://tinkerpop.apache.org/javadocs/x.y.z/core/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.html#temporalPageRank(java.lang.String)++[`temporalPageRank(String)`],
+link:++https://tinkerpop.apache.org/javadocs/x.y.z/core/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.html#temporalPageRank(double,java.lang.String,java.lang.String)++[`temporalPageRank(double,String,String)`],
+link:++https://tinkerpop.apache.org/javadocs/x.y.z/core/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.html#temporalPageRank(double,java.lang.String)++[`temporalPageRank(double,String)`]
+
 [[path-step]]
 === Path Step
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/step/map/TemporalPageRankVertexProgramStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/step/map/TemporalPageRankVertexProgramStep.java
@@ -171,7 +171,7 @@ public final class TemporalPageRankVertexProgramStep extends VertexProgramStep i
                                                                   final Element referenceElement) {
         final Traversal<Vertex, Edge> existingTraversal = baseComputer.getEdges();
         final Traversal.Admin<Vertex, Edge> baseTraversal = null == existingTraversal ?
-                this.edgeTraversal.getPure() :
+                __.<Vertex>bothE().asAdmin() :
                 existingTraversal.asAdmin().clone();
         return this.appendActiveWindowFilters(baseTraversal, referenceElement);
     }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/step/map/TemporalPageRankVertexProgramStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/step/map/TemporalPageRankVertexProgramStep.java
@@ -1,0 +1,217 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.tinkerpop.gremlin.process.computer.traversal.step.map;
+
+import org.apache.tinkerpop.gremlin.process.computer.Computer;
+import org.apache.tinkerpop.gremlin.process.computer.GraphFilter;
+import org.apache.tinkerpop.gremlin.process.computer.Memory;
+import org.apache.tinkerpop.gremlin.process.computer.ranking.pagerank.PageRankVertexProgram;
+import org.apache.tinkerpop.gremlin.process.computer.traversal.lambda.HaltedTraversersCountTraversal;
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategies;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
+import org.apache.tinkerpop.gremlin.process.traversal.step.Configuring;
+import org.apache.tinkerpop.gremlin.process.traversal.step.TraversalParent;
+import org.apache.tinkerpop.gremlin.process.traversal.step.util.Parameters;
+import org.apache.tinkerpop.gremlin.process.traversal.traverser.TraverserRequirement;
+import org.apache.tinkerpop.gremlin.process.traversal.util.AllenStep;
+import org.apache.tinkerpop.gremlin.process.traversal.util.PureTraversal;
+import org.apache.tinkerpop.gremlin.structure.Edge;
+import org.apache.tinkerpop.gremlin.structure.Element;
+import org.apache.tinkerpop.gremlin.structure.Graph;
+import org.apache.tinkerpop.gremlin.structure.T;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
+import org.apache.tinkerpop.gremlin.structure.util.star.StarGraph;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Temporal PageRank that projects the graph through a query-window reference element built by executing
+ * {@code lifetime(...)} on a temporary vertex.
+ */
+public final class TemporalPageRankVertexProgramStep extends VertexProgramStep implements TraversalParent, Configuring {
+
+    private Parameters parameters = new Parameters();
+    private PureTraversal<Vertex, Edge> edgeTraversal;
+    private String pageRankProperty = PageRankVertexProgram.PAGE_RANK;
+    private int times = 20;
+    private final double alpha;
+    private final String queryStartTime;
+    private final String queryEndTime;
+
+    public TemporalPageRankVertexProgramStep(final Traversal.Admin traversal, final double alpha,
+                                             final String queryStartTime, final String queryEndTime) {
+        super(traversal);
+        if (null == queryStartTime)
+            throw new IllegalArgumentException("Start time cannot be null");
+        this.alpha = alpha;
+        this.queryStartTime = queryStartTime;
+        this.queryEndTime = queryEndTime;
+        this.configure(PageRank.edges, __.<Vertex>outE().asAdmin());
+    }
+
+    @Override
+    public void configure(final Object... keyValues) {
+        if (keyValues[0].equals(PageRank.edges)) {
+            if (!(keyValues[1] instanceof Traversal))
+                throw new IllegalArgumentException("PageRank.edges requires a Traversal as its argument");
+            this.edgeTraversal = new PureTraversal<>(((Traversal<Vertex, Edge>) keyValues[1]).asAdmin());
+            this.integrateChild(this.edgeTraversal.get());
+        } else if (keyValues[0].equals(PageRank.propertyName)) {
+            if (!(keyValues[1] instanceof String))
+                throw new IllegalArgumentException("PageRank.propertyName requires a String as its argument");
+            this.pageRankProperty = (String) keyValues[1];
+        } else if (keyValues[0].equals(PageRank.times)) {
+            if (!(keyValues[1] instanceof Integer))
+                throw new IllegalArgumentException("PageRank.times requires an Integer as its argument");
+            this.times = (int) keyValues[1];
+        } else {
+            this.parameters.set(this, keyValues);
+        }
+    }
+
+    @Override
+    public Parameters getParameters() {
+        return this.parameters;
+    }
+
+    @Override
+    public List<Traversal.Admin<Vertex, Edge>> getLocalChildren() {
+        return Collections.singletonList(this.edgeTraversal.get());
+    }
+
+    @Override
+    public Computer getComputer() {
+        final TemporalWindowReference windowReference = this.createWindowReference();
+        final Computer baseComputer = super.getComputer();
+        return baseComputer
+                .vertices(this.buildComputerVertexFilter(baseComputer, windowReference.referenceElement))
+                .edges(this.buildComputerEdgeFilter(baseComputer, windowReference.referenceElement));
+    }
+
+    @Override
+    public String toString() {
+        final TemporalWindowReference windowReference = this.createWindowReference();
+        return StringFactory.stepString(this, this.edgeTraversal.get(), this.pageRankProperty, this.times,
+                windowReference.effectiveStartTime, windowReference.effectiveEndTime, new GraphFilter(this.getComputer()));
+    }
+
+    @Override
+    public PageRankVertexProgram generateProgram(final Graph graph, final Memory memory) {
+        final TemporalWindowReference windowReference = this.createWindowReference();
+        final Traversal.Admin<Vertex, Edge> filteredTraversal =
+                this.appendActiveWindowFilters(this.edgeTraversal.getPure(), windowReference.referenceElement);
+        filteredTraversal.setStrategies(TraversalStrategies.GlobalCache.getStrategies(graph.getClass()));
+
+        final PageRankVertexProgram.Builder builder = PageRankVertexProgram.build()
+                .property(this.pageRankProperty)
+                .iterations(this.times + 1)
+                .alpha(this.alpha)
+                .edges(filteredTraversal);
+        if (this.previousTraversalVertexProgram())
+            builder.initialRank(new HaltedTraversersCountTraversal());
+        return builder.create(graph);
+    }
+
+    @Override
+    public Set<TraverserRequirement> getRequirements() {
+        return TraversalParent.super.getSelfAndChildRequirements();
+    }
+
+    @Override
+    public TemporalPageRankVertexProgramStep clone() {
+        final TemporalPageRankVertexProgramStep clone = (TemporalPageRankVertexProgramStep) super.clone();
+        clone.edgeTraversal = this.edgeTraversal.clone();
+        return clone;
+    }
+
+    @Override
+    public void setTraversal(final Traversal.Admin<?, ?> parentTraversal) {
+        super.setTraversal(parentTraversal);
+        this.integrateChild(this.edgeTraversal.get());
+    }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode() ^ this.edgeTraversal.hashCode() ^ this.pageRankProperty.hashCode() ^ this.times ^
+                this.queryStartTime.hashCode() ^ (null == this.queryEndTime ? 0 : this.queryEndTime.hashCode());
+    }
+
+    private Traversal.Admin<Vertex, Vertex> buildComputerVertexFilter(final Computer baseComputer,
+                                                                      final Element referenceElement) {
+        final Traversal<Vertex, Vertex> existingTraversal = baseComputer.getVertices();
+        final Traversal.Admin<Vertex, Vertex> baseTraversal = null == existingTraversal ?
+                __.<Vertex>start().asAdmin() :
+                existingTraversal.asAdmin().clone();
+        return this.appendActiveWindowFilters(baseTraversal, referenceElement);
+    }
+
+    private Traversal.Admin<Vertex, Edge> buildComputerEdgeFilter(final Computer baseComputer,
+                                                                  final Element referenceElement) {
+        final Traversal<Vertex, Edge> existingTraversal = baseComputer.getEdges();
+        final Traversal.Admin<Vertex, Edge> baseTraversal = null == existingTraversal ?
+                this.edgeTraversal.getPure() :
+                existingTraversal.asAdmin().clone();
+        return this.appendActiveWindowFilters(baseTraversal, referenceElement);
+    }
+
+    private <S, E extends Element> Traversal.Admin<S, E> appendActiveWindowFilters(final Traversal.Admin<S, E> traversal,
+                                                                                   final Element referenceElement) {
+        final GraphTraversal.Admin<S, E> graphTraversal = (GraphTraversal.Admin<S, E>) traversal;
+        graphTraversal.not(this.createAllenRelationTraversal(AllenStep.AllenRelation.BEFORE, referenceElement));
+        if (null != this.queryEndTime) {
+            graphTraversal.not(this.createAllenRelationTraversal(AllenStep.AllenRelation.AFTER, referenceElement));
+        }
+        return graphTraversal;
+    }
+
+    private <E extends Element> Traversal.Admin<E, E> createAllenRelationTraversal(final AllenStep.AllenRelation relation,
+                                                                                    final Element referenceElement) {
+        return AllenStep.applyTemporalFilter(__.<E>start(), relation, referenceElement).asAdmin();
+    }
+
+    private TemporalWindowReference createWindowReference() {
+        final StarGraph windowGraph = StarGraph.open();
+        final Vertex referenceVertex = windowGraph.addVertex(T.label, "temporalPageRankWindow");
+
+        windowGraph.traversal().V(referenceVertex.id()).lifetime(this.queryStartTime, this.queryEndTime).iterate();
+
+        final String effectiveStartTime = referenceVertex.value("startTime");
+        final String effectiveEndTime = referenceVertex.value("endTime");
+        return new TemporalWindowReference(referenceVertex, effectiveStartTime, effectiveEndTime);
+    }
+
+    private static final class TemporalWindowReference {
+        private final Element referenceElement;
+        private final String effectiveStartTime;
+        private final String effectiveEndTime;
+
+        private TemporalWindowReference(final Element referenceElement, final String effectiveStartTime,
+                                        final String effectiveEndTime) {
+            this.referenceElement = referenceElement;
+            this.effectiveStartTime = effectiveStartTime;
+            this.effectiveEndTime = effectiveEndTime;
+        }
+    }
+}

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/step/map/TemporalPageRankVertexProgramStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/step/map/TemporalPageRankVertexProgramStep.java
@@ -20,6 +20,7 @@
 package org.apache.tinkerpop.gremlin.process.computer.traversal.step.map;
 
 import org.apache.tinkerpop.gremlin.process.computer.Computer;
+import org.apache.tinkerpop.gremlin.process.computer.GraphComputer;
 import org.apache.tinkerpop.gremlin.process.computer.GraphFilter;
 import org.apache.tinkerpop.gremlin.process.computer.Memory;
 import org.apache.tinkerpop.gremlin.process.computer.ranking.pagerank.PageRankVertexProgram;
@@ -104,10 +105,11 @@ public final class TemporalPageRankVertexProgramStep extends VertexProgramStep i
     @Override
     public Computer getComputer() {
         final TemporalWindowReference windowReference = this.createWindowReference();
-        final Computer baseComputer = super.getComputer();
-        return baseComputer
-                .vertices(this.buildComputerVertexFilter(baseComputer, windowReference.referenceElement))
-                .edges(this.buildComputerEdgeFilter(baseComputer, windowReference.referenceElement));
+        Computer baseComputer = this.computer;
+        if (!this.isEndStep() && null == baseComputer.getResultGraph()) {
+            baseComputer = baseComputer.result(GraphComputer.ResultGraph.NEW);
+        }
+        return baseComputer.vertices(this.buildComputerVertexFilter(baseComputer, windowReference.referenceElement));
     }
 
     @Override
@@ -163,15 +165,6 @@ public final class TemporalPageRankVertexProgramStep extends VertexProgramStep i
         final Traversal<Vertex, Vertex> existingTraversal = baseComputer.getVertices();
         final Traversal.Admin<Vertex, Vertex> baseTraversal = null == existingTraversal ?
                 __.<Vertex>start().asAdmin() :
-                existingTraversal.asAdmin().clone();
-        return this.appendActiveWindowFilters(baseTraversal, referenceElement);
-    }
-
-    private Traversal.Admin<Vertex, Edge> buildComputerEdgeFilter(final Computer baseComputer,
-                                                                  final Element referenceElement) {
-        final Traversal<Vertex, Edge> existingTraversal = baseComputer.getEdges();
-        final Traversal.Admin<Vertex, Edge> baseTraversal = null == existingTraversal ?
-                __.<Vertex>bothE().asAdmin() :
                 existingTraversal.asAdmin().clone();
         return this.appendActiveWindowFilters(baseTraversal, referenceElement);
     }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.java
@@ -25,6 +25,7 @@ import org.apache.tinkerpop.gremlin.process.computer.traversal.step.map.PageRank
 import org.apache.tinkerpop.gremlin.process.computer.traversal.step.map.PeerPressureVertexProgramStep;
 import org.apache.tinkerpop.gremlin.process.computer.traversal.step.map.ProgramVertexProgramStep;
 import org.apache.tinkerpop.gremlin.process.computer.traversal.step.map.ShortestPathVertexProgramStep;
+import org.apache.tinkerpop.gremlin.process.computer.traversal.step.map.TemporalPageRankVertexProgramStep;
 import org.apache.tinkerpop.gremlin.process.traversal.DT;
 import org.apache.tinkerpop.gremlin.process.traversal.Failure;
 import org.apache.tinkerpop.gremlin.process.traversal.Merge;
@@ -3825,6 +3826,63 @@ public interface GraphTraversal<S, E> extends Traversal<S, E> {
     }
 
     /**
+     * Execute a temporal variant of {@link #pageRank()} against the subgraph that intersects the supplied query
+     * window. The effective window is normalized by applying {@link #lifetime(String, String)} to a reference
+     * element before the Allen-based graph filters are built.
+     *
+     * @param startTime the query window start time
+     * @param endTime the query window end time
+     * @return the traversal with the appended {@link TemporalPageRankVertexProgramStep}
+     * @since 4.0.0-temporal
+     */
+    public default GraphTraversal<S, E> temporalPageRank(final String startTime, final String endTime) {
+        this.asAdmin().getBytecode().addStep(Symbols.temporalPageRank, startTime, endTime);
+        return this.asAdmin().addStep((Step<E, E>) new TemporalPageRankVertexProgramStep(this.asAdmin(), 0.85d, startTime, endTime));
+    }
+
+    /**
+     * Execute a temporal variant of {@link #pageRank(double)} against an open-ended window that starts at the
+     * supplied time.
+     *
+     * @param startTime the query window start time
+     * @return the traversal with the appended {@link TemporalPageRankVertexProgramStep}
+     * @since 4.0.0-temporal
+     */
+    public default GraphTraversal<S, E> temporalPageRank(final String startTime) {
+        this.asAdmin().getBytecode().addStep(Symbols.temporalPageRank, startTime);
+        return this.asAdmin().addStep((Step<E, E>) new TemporalPageRankVertexProgramStep(this.asAdmin(), 0.85d, startTime, null));
+    }
+
+    /**
+     * Execute a temporal variant of {@link #pageRank(double)} against the subgraph that intersects the supplied
+     * query window.
+     *
+     * @param alpha the damping factor
+     * @param startTime the query window start time
+     * @param endTime the query window end time
+     * @return the traversal with the appended {@link TemporalPageRankVertexProgramStep}
+     * @since 4.0.0-temporal
+     */
+    public default GraphTraversal<S, E> temporalPageRank(final double alpha, final String startTime, final String endTime) {
+        this.asAdmin().getBytecode().addStep(Symbols.temporalPageRank, alpha, startTime, endTime);
+        return this.asAdmin().addStep((Step<E, E>) new TemporalPageRankVertexProgramStep(this.asAdmin(), alpha, startTime, endTime));
+    }
+
+    /**
+     * Execute a temporal variant of {@link #pageRank(double)} against an open-ended window that starts at the
+     * supplied time.
+     *
+     * @param alpha the damping factor
+     * @param startTime the query window start time
+     * @return the traversal with the appended {@link TemporalPageRankVertexProgramStep}
+     * @since 4.0.0-temporal
+     */
+    public default GraphTraversal<S, E> temporalPageRank(final double alpha, final String startTime) {
+        this.asAdmin().getBytecode().addStep(Symbols.temporalPageRank, alpha, startTime);
+        return this.asAdmin().addStep((Step<E, E>) new TemporalPageRankVertexProgramStep(this.asAdmin(), alpha, startTime, null));
+    }
+
+    /**
      * Executes a Peer Pressure community detection algorithm over the graph.
      *
      * @return the traversal with the appended {@link PeerPressureVertexProgramStep}
@@ -4541,6 +4599,7 @@ public interface GraphTraversal<S, E> extends Traversal<S, E> {
 
 
         public static final String pageRank = "pageRank";
+        public static final String temporalPageRank = "temporalPageRank";
         public static final String peerPressure = "peerPressure";
         public static final String connectedComponent = "connectedComponent";
         public static final String shortestPath = "shortestPath";

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/BytecodeHelper.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/BytecodeHelper.java
@@ -28,6 +28,7 @@ import org.apache.tinkerpop.gremlin.process.computer.traversal.step.map.PageRank
 import org.apache.tinkerpop.gremlin.process.computer.traversal.step.map.PeerPressureVertexProgramStep;
 import org.apache.tinkerpop.gremlin.process.computer.traversal.step.map.ProgramVertexProgramStep;
 import org.apache.tinkerpop.gremlin.process.computer.traversal.step.map.ShortestPathVertexProgramStep;
+import org.apache.tinkerpop.gremlin.process.computer.traversal.step.map.TemporalPageRankVertexProgramStep;
 import org.apache.tinkerpop.gremlin.process.traversal.Bytecode;
 import org.apache.tinkerpop.gremlin.process.traversal.GraphOp;
 import org.apache.tinkerpop.gremlin.process.traversal.Step;
@@ -339,6 +340,7 @@ public final class BytecodeHelper {
             put(GraphTraversal.Symbols.choose, Collections.singletonList(ChooseStep.class));
             put(GraphTraversal.Symbols.optional, Collections.singletonList(OptionalStep.class));
             put(GraphTraversal.Symbols.pageRank, Collections.singletonList(PageRankVertexProgramStep.class));
+            put(GraphTraversal.Symbols.temporalPageRank, Collections.singletonList(TemporalPageRankVertexProgramStep.class));
             put(GraphTraversal.Symbols.peerPressure, Collections.singletonList(PeerPressureVertexProgramStep.class));
             put(GraphTraversal.Symbols.connectedComponent, Collections.singletonList(ConnectedComponentVertexProgramStep.class));
             put(GraphTraversal.Symbols.shortestPath, Collections.singletonList(ShortestPathVertexProgramStep.class));

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/ProcessComputerSuite.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/ProcessComputerSuite.java
@@ -74,6 +74,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.map.ReadTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.ShortestPathTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.SumTest;
+import org.apache.tinkerpop.gremlin.process.traversal.step.map.TemporalPageRankTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.UnfoldTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.ValueMapTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.VertexTest;
@@ -174,6 +175,7 @@ public class ProcessComputerSuite extends AbstractGremlinSuite {
             ShortestPathTest.Traversals.class,
             SelectTest.Traversals.class,
             UnfoldTest.Traversals.class,
+            TemporalPageRankTest.Traversals.class,
             ValueMapTest.Traversals.class,
             VertexTest.Traversals.class,
             WriteTest.Traversals.class,
@@ -267,6 +269,7 @@ public class ProcessComputerSuite extends AbstractGremlinSuite {
             PropertiesTest.class,
             ShortestPathTest.class,
             SelectTest.class,
+            TemporalPageRankTest.class,
             UnfoldTest.class,
             ValueMapTest.class,
             VertexTest.class,

--- a/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/process/computer/TinkerGraphComputerView.java
+++ b/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/process/computer/TinkerGraphComputerView.java
@@ -143,7 +143,10 @@ public final class TinkerGraphComputerView {
     }
 
     public boolean legalEdge(final Vertex vertex, final Edge edge) {
-        return !this.graphFilter.hasEdgeFilter() || this.legalEdges.get(vertex.id()).contains(edge.id());
+        if (!this.graphFilter.hasEdgeFilter()) return true;
+
+        final Set<Object> edgeIds = this.legalEdges.get(vertex.id());
+        return null != edgeIds && edgeIds.contains(edge.id());
     }
 
     protected void complete() {

--- a/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/process/computer/TinkerGraphComputerView.java
+++ b/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/process/computer/TinkerGraphComputerView.java
@@ -143,10 +143,7 @@ public final class TinkerGraphComputerView {
     }
 
     public boolean legalEdge(final Vertex vertex, final Edge edge) {
-        if (!this.graphFilter.hasEdgeFilter()) return true;
-
-        final Set<Object> edgeIds = this.legalEdges.get(vertex.id());
-        return null != edgeIds && edgeIds.contains(edge.id());
+        return !this.graphFilter.hasEdgeFilter() || this.legalEdges.get(vertex.id()).contains(edge.id());
     }
 
     protected void complete() {

--- a/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/process/traversal/TemporalPageRankIntegrationTest.java
+++ b/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/process/traversal/TemporalPageRankIntegrationTest.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.tinkergraph.process.traversal;
+
+import org.apache.tinkerpop.gremlin.process.computer.traversal.step.map.PageRank;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerGraph;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class TemporalPageRankIntegrationTest {
+
+    private TinkerGraph graph;
+    private GraphTraversalSource g;
+    private GraphTraversalSource computerG;
+
+    @Before
+    public void setUp() {
+        graph = TinkerGraph.open();
+        g = graph.traversal();
+        computerG = graph.traversal().withComputer();
+    }
+
+    @Test
+    public void testTemporalPageRankWithinClosedWindow() {
+        loadTemporalPageRankFixture();
+
+        final Map<String, Double> ranksByName = mapRanksByName(computerG.V()
+                .temporalPageRank("2020-01-01", "2020-12-31")
+                .with(PageRank.propertyName, "windowRank")
+                .project("name", "windowRank")
+                .by("name")
+                .by(__.values("windowRank"))
+                .toList());
+
+        assertEquals(2, ranksByName.size());
+        assertTrue(ranksByName.containsKey("alice"));
+        assertTrue(ranksByName.containsKey("bob"));
+        assertTrue(ranksByName.get("alice") > 0.0d);
+        assertEquals(ranksByName.get("alice"), ranksByName.get("bob"), 0.00001d);
+    }
+
+    @Test
+    public void testTemporalPageRankWithinOpenEndedWindow() {
+        loadTemporalPageRankFixture();
+
+        final Map<String, Double> ranksByName = mapRanksByName(computerG.V()
+                .temporalPageRank("2021-01-01")
+                .with(PageRank.propertyName, "windowRank")
+                .project("name", "windowRank")
+                .by("name")
+                .by(__.values("windowRank"))
+                .toList());
+
+        assertEquals(2, ranksByName.size());
+        assertTrue(ranksByName.containsKey("carol"));
+        assertTrue(ranksByName.containsKey("dave"));
+        assertTrue(ranksByName.get("carol") > 0.0d);
+        assertEquals(ranksByName.get("carol"), ranksByName.get("dave"), 0.00001d);
+    }
+
+    private void loadTemporalPageRankFixture() {
+        final Vertex alice = g.addV("person").property("name", "alice").lifetime("2020-01-01", "2020-12-31").next();
+        final Vertex bob = g.addV("person").property("name", "bob").lifetime("2020-01-01", "2020-12-31").next();
+        final Vertex carol = g.addV("person").property("name", "carol").lifetime("2022-01-01", "2022-12-31").next();
+        final Vertex dave = g.addV("person").property("name", "dave").lifetime("2022-01-01", "2022-12-31").next();
+
+        g.addE("knows").from(alice).to(bob).lifetime("2020-01-01", "2020-12-31").iterate();
+        g.addE("knows").from(bob).to(alice).lifetime("2020-01-01", "2020-12-31").iterate();
+        g.addE("knows").from(carol).to(dave).lifetime("2022-01-01", "2022-12-31").iterate();
+        g.addE("knows").from(dave).to(carol).lifetime("2022-01-01", "2022-12-31").iterate();
+    }
+
+    private static Map<String, Double> mapRanksByName(final List<Map<String, Object>> results) {
+        final Map<String, Double> ranksByName = new LinkedHashMap<>();
+        results.forEach(result -> ranksByName.put((String) result.get("name"), ((Number) result.get("windowRank")).doubleValue()));
+        return ranksByName;
+    }
+}

--- a/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/process/traversal/TemporalPageRankIntegrationTest.java
+++ b/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/process/traversal/TemporalPageRankIntegrationTest.java
@@ -42,6 +42,7 @@ public class TemporalPageRankIntegrationTest {
 
     private static final int PAGE_RANK_ITERATIONS = 30;
     private static final String FAR_FUTURE_END_TIME = "9999-12-31";
+    private static final String FAR_FUTURE_END_DATE_TIME = "9999-12-31T23:59:59";
 
     private TinkerGraph graph;
     private GraphTraversalSource g;
@@ -79,6 +80,44 @@ public class TemporalPageRankIntegrationTest {
 
         final Map<String, Double> ranksByName = mapRanksByName(computerG.V()
                 .temporalPageRank("2021-01-01")
+                .with(PageRank.propertyName, "windowRank")
+                .project("name", "windowRank")
+                .by("name")
+                .by(__.values("windowRank"))
+                .toList());
+
+        assertEquals(2, ranksByName.size());
+        assertTrue(ranksByName.containsKey("carol"));
+        assertTrue(ranksByName.containsKey("dave"));
+        assertTrue(ranksByName.get("carol") > 0.0d);
+        assertEquals(ranksByName.get("carol"), ranksByName.get("dave"), 0.00001d);
+    }
+
+    @Test
+    public void testTemporalPageRankWithinClosedDateTimeWindow() {
+        loadTemporalPageRankDateTimeFixture();
+
+        final Map<String, Double> ranksByName = mapRanksByName(computerG.V()
+                .temporalPageRank("2020-01-01T09:30:00", "2020-01-01T10:30:00")
+                .with(PageRank.propertyName, "windowRank")
+                .project("name", "windowRank")
+                .by("name")
+                .by(__.values("windowRank"))
+                .toList());
+
+        assertEquals(2, ranksByName.size());
+        assertTrue(ranksByName.containsKey("alice"));
+        assertTrue(ranksByName.containsKey("bob"));
+        assertTrue(ranksByName.get("alice") > 0.0d);
+        assertEquals(ranksByName.get("alice"), ranksByName.get("bob"), 0.00001d);
+    }
+
+    @Test
+    public void testTemporalPageRankWithinOpenEndedDateTimeWindow() {
+        loadTemporalPageRankDateTimeFixture();
+
+        final Map<String, Double> ranksByName = mapRanksByName(computerG.V()
+                .temporalPageRank("2020-01-01T11:15:00")
                 .with(PageRank.propertyName, "windowRank")
                 .project("name", "windowRank")
                 .by("name")
@@ -182,6 +221,29 @@ public class TemporalPageRankIntegrationTest {
     }
 
     @Test
+    public void shouldTreatDateTimeLifetimeBoundariesAsInclusive() {
+        final Vertex a = addVertex("a", "2020-01-01T09:00:00", FAR_FUTURE_END_DATE_TIME);
+        final Vertex b = addVertex("b", "2020-01-01T08:45:00", "2020-01-01T10:30:00");
+        final Vertex c = addVertex("c", "2020-01-01T10:30:00", "2020-01-01T10:30:00");
+
+        addEdge(a, b, "link", "2020-01-01T09:00:00", FAR_FUTURE_END_DATE_TIME);
+        addEdge(b, a, "link", "2020-01-01T08:45:00", "2020-01-01T10:30:00");
+        addEdge(a, c, "link", "2020-01-01T10:30:00", "2020-01-01T10:30:00");
+        addEdge(c, a, "link", "2020-01-01T10:30:00", "2020-01-01T10:30:00");
+
+        final Map<String, Double> temporal = computeRanks(
+                "boundaryDateTimeRank", "2020-01-01T09:00:00", "2020-01-01T10:30:00", null);
+
+        assertEquals(3, temporal.size());
+        assertTrue(temporal.containsKey("a"));
+        assertTrue(temporal.containsKey("b"));
+        assertTrue(temporal.containsKey("c"));
+
+        assertPositiveRanks(temporal);
+        assertTrue(temporal.get("c") > 0.0d);
+    }
+
+    @Test
     public void shouldFilterInactiveEdgesAndVerticesWhenUsingCustomEdgesTraversal() {
         final Vertex a = addVertex("a", "2020-01-01", "2020-12-31");
         final Vertex b = addVertex("b", "2020-01-01", "2020-12-31");
@@ -269,6 +331,22 @@ public class TemporalPageRankIntegrationTest {
         g.addE("knows").from(bob).to(alice).lifetime("2020-01-01", "2020-12-31").iterate();
         g.addE("knows").from(carol).to(dave).lifetime("2022-01-01", "2022-12-31").iterate();
         g.addE("knows").from(dave).to(carol).lifetime("2022-01-01", "2022-12-31").iterate();
+    }
+
+    private void loadTemporalPageRankDateTimeFixture() {
+        final Vertex alice = g.addV("person").property("name", "alice")
+                .lifetime("2020-01-01T09:15:00", "2020-01-01T10:45:00").next();
+        final Vertex bob = g.addV("person").property("name", "bob")
+                .lifetime("2020-01-01T09:15:00", "2020-01-01T10:45:00").next();
+        final Vertex carol = g.addV("person").property("name", "carol")
+                .lifetime("2020-01-01T11:00:00", "2020-01-01T12:30:00").next();
+        final Vertex dave = g.addV("person").property("name", "dave")
+                .lifetime("2020-01-01T11:00:00", "2020-01-01T12:30:00").next();
+
+        g.addE("knows").from(alice).to(bob).lifetime("2020-01-01T09:15:00", "2020-01-01T10:45:00").iterate();
+        g.addE("knows").from(bob).to(alice).lifetime("2020-01-01T09:15:00", "2020-01-01T10:45:00").iterate();
+        g.addE("knows").from(carol).to(dave).lifetime("2020-01-01T11:00:00", "2020-01-01T12:30:00").iterate();
+        g.addE("knows").from(dave).to(carol).lifetime("2020-01-01T11:00:00", "2020-01-01T12:30:00").iterate();
     }
 
     private Vertex addVertex(final String name) {

--- a/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/process/traversal/TemporalPageRankIntegrationTest.java
+++ b/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/process/traversal/TemporalPageRankIntegrationTest.java
@@ -19,8 +19,11 @@
 package org.apache.tinkerpop.gremlin.tinkergraph.process.traversal;
 
 import org.apache.tinkerpop.gremlin.process.computer.traversal.step.map.PageRank;
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
+import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerGraph;
 import org.junit.Before;
@@ -31,9 +34,14 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 public class TemporalPageRankIntegrationTest {
+
+    private static final int PAGE_RANK_ITERATIONS = 30;
+    private static final String FAR_FUTURE_END_TIME = "9999-12-31";
 
     private TinkerGraph graph;
     private GraphTraversalSource g;
@@ -84,6 +92,173 @@ public class TemporalPageRankIntegrationTest {
         assertEquals(ranksByName.get("carol"), ranksByName.get("dave"), 0.00001d);
     }
 
+    @Test
+    public void shouldPreservePlainPageRankAndChangeRanksForDifferentTemporalWindows() {
+        final Vertex a = addVertex("a", "2020-01-01");
+        final Vertex b = addVertex("b", "2020-01-01");
+        final Vertex c = addVertex("c", "2020-01-01");
+        final Vertex d = addVertex("d", "2021-01-01");
+
+        addEdge(a, b, "link", "2020-01-01", FAR_FUTURE_END_TIME);
+        addEdge(b, c, "link", "2020-01-01", FAR_FUTURE_END_TIME);
+        addEdge(c, a, "link", "2020-01-01", FAR_FUTURE_END_TIME);
+
+        addEdge(a, d, "link", "2021-01-01", FAR_FUTURE_END_TIME);
+        addEdge(d, b, "link", "2021-01-01", FAR_FUTURE_END_TIME);
+        addEdge(d, c, "link", "2021-01-01", FAR_FUTURE_END_TIME);
+
+        final Map<String, Double> plainBeforeTemporal = computeRanks("rankAllBefore", null, null, null);
+        final Map<String, Double> window2020 = computeRanks("rank2020", "2020-01-01", "2020-12-31", null);
+        final Map<String, Double> window2021OpenEnded = computeRanks("rank2021", "2021-01-01", null, null);
+        final Map<String, Double> plainAfterTemporal = computeRanks("rankAllAfter", null, null, null);
+
+        assertPositiveRanks(plainBeforeTemporal);
+        assertPositiveRanks(window2020);
+        assertPositiveRanks(window2021OpenEnded);
+        assertPositiveRanks(plainAfterTemporal);
+
+        assertEquals(4, plainBeforeTemporal.size());
+        assertEquals(3, window2020.size());
+        assertEquals(4, window2021OpenEnded.size());
+        assertEquals(4, plainAfterTemporal.size());
+
+        assertFalse(window2020.containsKey("d"));
+        assertTrue(window2021OpenEnded.containsKey("d"));
+
+        assertTrue(window2020.get("a") > 0.0d);
+        assertEquals(window2020.get("a"), window2020.get("b"), 0.02d);
+        assertEquals(window2020.get("b"), window2020.get("c"), 0.02d);
+
+        assertTrue(Math.abs(window2020.get("a") - window2021OpenEnded.get("a")) > 0.000000001d);
+
+        assertMatchingRanks(plainBeforeTemporal, window2021OpenEnded, 0.000001d);
+        assertMatchingRanks(plainBeforeTemporal, plainAfterTemporal, 0.000001d);
+    }
+
+    @Test
+    public void shouldTreatElementsWithoutTemporalPropertiesAsAlwaysActive() {
+        final Vertex timelessA = addVertex("timelessA");
+        final Vertex timelessB = addVertex("timelessB");
+        final Vertex future = addVertex("future", "2022-01-01");
+
+        addEdge(timelessA, timelessB, "link");
+        addEdge(timelessB, timelessA, "link");
+        addEdge(future, timelessA, "link", "2022-01-01", FAR_FUTURE_END_TIME);
+
+        final Map<String, Double> plain = computeRanks("plainRank", null, null, null);
+        final Map<String, Double> temporal = computeRanks("temporalRank", "2020-01-01", "2020-12-31", null);
+
+        assertEquals(3, plain.size());
+        assertEquals(2, temporal.size());
+        assertTrue(temporal.containsKey("timelessA"));
+        assertTrue(temporal.containsKey("timelessB"));
+        assertFalse(temporal.containsKey("future"));
+
+        assertPositiveRanks(temporal);
+        assertTrue(temporal.get("timelessA") > 0.0d);
+        assertEquals(temporal.get("timelessA"), temporal.get("timelessB"), 0.02d);
+    }
+
+    @Test
+    public void shouldTreatLifetimeBoundariesAsInclusive() {
+        final Vertex a = addVertex("a", "2020-01-01", FAR_FUTURE_END_TIME);
+        final Vertex b = addVertex("b", "2019-01-01", "2020-12-31");
+        final Vertex c = addVertex("c", "2020-12-31", "2020-12-31");
+
+        addEdge(a, b, "link", "2020-01-01", FAR_FUTURE_END_TIME);
+        addEdge(b, a, "link", "2019-01-01", "2020-12-31");
+        addEdge(a, c, "link", "2020-12-31", "2020-12-31");
+        addEdge(c, a, "link", "2020-12-31", "2020-12-31");
+
+        final Map<String, Double> temporal = computeRanks("boundaryRank", "2020-01-01", "2020-12-31", null);
+
+        assertEquals(3, temporal.size());
+        assertTrue(temporal.containsKey("a"));
+        assertTrue(temporal.containsKey("b"));
+        assertTrue(temporal.containsKey("c"));
+
+        assertPositiveRanks(temporal);
+        assertTrue(temporal.get("c") > 0.0d);
+    }
+
+    @Test
+    public void shouldFilterInactiveEdgesAndVerticesWhenUsingCustomEdgesTraversal() {
+        final Vertex a = addVertex("a", "2020-01-01", "2020-12-31");
+        final Vertex b = addVertex("b", "2020-01-01", "2020-12-31");
+        final Vertex c = addVertex("c", "2020-01-01", "2020-12-31");
+        final Vertex inactiveFuture = addVertex("inactiveFuture", "2021-01-01", FAR_FUTURE_END_TIME);
+
+        addEdge(a, b, "link", "2020-01-01", "2020-12-31");
+        addEdge(b, c, "link", "2020-01-01", "2020-12-31");
+        addEdge(c, a, "link", "2020-01-01", "2020-12-31");
+
+        addEdge(b, a, "link", "2021-01-01", "2021-12-31");
+        addEdge(a, c, "ignored", "2020-01-01", "2020-12-31");
+
+        final Map<String, Double> temporal = computeRanks("customRank", "2020-01-01", "2020-12-31",
+                __.<Vertex>outE("link").asAdmin());
+
+        assertEquals(3, temporal.size());
+        assertTrue(temporal.containsKey("a"));
+        assertTrue(temporal.containsKey("b"));
+        assertTrue(temporal.containsKey("c"));
+        assertFalse(temporal.containsKey("inactiveFuture"));
+
+        assertPositiveRanks(temporal);
+        assertTrue(temporal.get("a") > 0.0d);
+        assertEquals(temporal.get("a"), temporal.get("b"), 0.02d);
+        assertEquals(temporal.get("b"), temporal.get("c"), 0.02d);
+    }
+
+    @Test
+    public void shouldProduceSameTemporalRanksRegardlessOfWhenCustomEdgesAreConfigured() {
+        final Vertex a = addVertex("a", "2020-01-01", "2020-12-31");
+        final Vertex b = addVertex("b", "2020-01-01", "2020-12-31");
+        final Vertex c = addVertex("c", "2020-01-01", "2020-12-31");
+        final Vertex future = addVertex("future", "2021-01-01", FAR_FUTURE_END_TIME);
+
+        addEdge(a, b, "link", "2020-01-01", "2020-12-31");
+        addEdge(a, c, "link", "2020-01-01", "2020-12-31");
+        addEdge(b, c, "link", "2020-01-01", "2020-12-31");
+        addEdge(c, a, "link", "2020-01-01", "2020-12-31");
+        addEdge(future, a, "link", "2021-01-01", FAR_FUTURE_END_TIME);
+        addEdge(a, future, "link", "2021-01-01", FAR_FUTURE_END_TIME);
+
+        final Traversal.Admin<Vertex, Edge> inboundLinks = __.<Vertex>inE("link").asAdmin();
+
+        final Map<String, Double> edgesBeforeOptions = computeRanks(
+                "rankEdgesBeforeOptions", "2020-01-01", "2020-12-31", inboundLinks, true);
+        final Map<String, Double> edgesAfterOptions = computeRanks(
+                "rankEdgesAfterOptions", "2020-01-01", "2020-12-31", inboundLinks, false);
+
+        assertEquals(3, edgesBeforeOptions.size());
+        assertFalse(edgesBeforeOptions.containsKey("future"));
+        assertPositiveRanks(edgesBeforeOptions);
+        assertEquals(edgesBeforeOptions.keySet(), edgesAfterOptions.keySet());
+        assertMatchingRanks(edgesBeforeOptions, edgesAfterOptions, 0.000001d);
+    }
+
+    @Test
+    public void shouldRequireStartTimeForTemporalPageRank() {
+        final IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> this.computerG.V().temporalPageRank(null, "2020-12-31"));
+
+        assertEquals("Start time cannot be null", exception.getMessage());
+    }
+
+    @Test
+    public void shouldReturnNoRanksWhenNoVerticesAreActiveInWindow() {
+        final Vertex a = addVertex("a", "2020-01-01", "2020-12-31");
+        final Vertex b = addVertex("b", "2020-01-01", "2020-12-31");
+
+        addEdge(a, b, "link", "2020-01-01", "2020-12-31");
+        addEdge(b, a, "link", "2020-01-01", "2020-12-31");
+
+        final Map<String, Double> temporal = computeRanks("emptyRank", "2030-01-01", "2030-12-31", null);
+
+        assertTrue(temporal.isEmpty());
+    }
+
     private void loadTemporalPageRankFixture() {
         final Vertex alice = g.addV("person").property("name", "alice").lifetime("2020-01-01", "2020-12-31").next();
         final Vertex bob = g.addV("person").property("name", "bob").lifetime("2020-01-01", "2020-12-31").next();
@@ -94,6 +269,67 @@ public class TemporalPageRankIntegrationTest {
         g.addE("knows").from(bob).to(alice).lifetime("2020-01-01", "2020-12-31").iterate();
         g.addE("knows").from(carol).to(dave).lifetime("2022-01-01", "2022-12-31").iterate();
         g.addE("knows").from(dave).to(carol).lifetime("2022-01-01", "2022-12-31").iterate();
+    }
+
+    private Vertex addVertex(final String name) {
+        return this.graph.addVertex("name", name);
+    }
+
+    private Vertex addVertex(final String name, final String startTime) {
+        return addVertex(name, startTime, FAR_FUTURE_END_TIME);
+    }
+
+    private Vertex addVertex(final String name, final String startTime, final String endTime) {
+        return this.graph.addVertex("name", name, "startTime", startTime, "endTime", endTime);
+    }
+
+    private void addEdge(final Vertex out, final Vertex in, final String label) {
+        out.addEdge(label, in);
+    }
+
+    private void addEdge(final Vertex out, final Vertex in, final String label, final String startTime,
+                         final String endTime) {
+        out.addEdge(label, in, "startTime", startTime, "endTime", endTime);
+    }
+
+    private Map<String, Double> computeRanks(final String propertyName, final String startTime, final String endTime,
+                                             final Traversal.Admin<Vertex, Edge> edgeTraversal) {
+        return computeRanks(propertyName, startTime, endTime, edgeTraversal, true);
+    }
+
+    private Map<String, Double> computeRanks(final String propertyName, final String startTime, final String endTime,
+                                             final Traversal.Admin<Vertex, Edge> edgeTraversal,
+                                             final boolean configureEdgesBeforeOptions) {
+        GraphTraversal<Vertex, Vertex> traversal =
+                null == startTime ? this.computerG.V().pageRank() :
+                        (null == endTime ? this.computerG.V().temporalPageRank(startTime) :
+                                this.computerG.V().temporalPageRank(startTime, endTime));
+
+        if (configureEdgesBeforeOptions && null != edgeTraversal) {
+            traversal = traversal.with(PageRank.edges, edgeTraversal.clone());
+        }
+
+        traversal = traversal.with(PageRank.propertyName, propertyName)
+                .with(PageRank.times, PAGE_RANK_ITERATIONS);
+
+        if (!configureEdgesBeforeOptions && null != edgeTraversal) {
+            traversal = traversal.with(PageRank.edges, edgeTraversal.clone());
+        }
+
+        final Map<String, Double> ranks = new LinkedHashMap<>();
+        traversal.has(propertyName).forEachRemaining(vertex -> ranks.put(vertex.value("name"), vertex.<Double>value(propertyName)));
+        return ranks;
+    }
+
+    private void assertMatchingRanks(final Map<String, Double> expected, final Map<String, Double> actual,
+                                     final double delta) {
+        assertEquals(expected.size(), actual.size());
+        expected.forEach((name, rank) -> assertEquals(rank, actual.get(name), delta));
+    }
+
+    private void assertPositiveRanks(final Map<String, Double> ranks) {
+        assertFalse(ranks.isEmpty());
+        ranks.values().forEach(rank -> assertTrue(rank > 0.0d));
     }
 
     private static Map<String, Double> mapRanksByName(final List<Map<String, Object>> results) {

--- a/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/process/traversal/TemporalPathIntegrationTest.java
+++ b/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/process/traversal/TemporalPathIntegrationTest.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 // TemporalPathIntegrationTest.java
 // Using clean DSL syntax instead of manual step construction
 


### PR DESCRIPTION
### New temporal PageRank traversal step

- Added `TemporalPageRankVertexProgramStep`, a new OLAP traversal step that runs PageRank only on the part of the graph active inside a requested time window.

- The step requires a `startTime`, accepts an optional `endTime`, and keeps the usual PageRank configuration points such as `PageRank.edges`, `PageRank.propertyName`, and `PageRank.times`.

- Instead of creating a brand new PageRank vertex program, the implementation reuses the existing `PageRankVertexProgram` and adds temporal behavior around it by filtering the graph before execution.

### Time-window normalization and filtering

- The new step creates a temporary reference vertex in a `StarGraph` and applies `lifetime(startTime, endTime)` to it. That makes the query window go through the same normalization rules already used elsewhere for temporal data.

- It then builds Allen-based filters that remove vertices and edges that are entirely `BEFORE` the query window and, for closed windows, also remove elements entirely `AFTER` the window.

- Those filters are applied both to the `GraphComputer` view of the graph and to the edge traversal given to the PageRank program, so the algorithm runs only over the active temporal slice.

### New Gremlin DSL entry points

- Added four new `GraphTraversal.temporalPageRank(...)` overloads:

```java
temporalPageRank(String startTime, String endTime)
temporalPageRank(String startTime)
temporalPageRank(double alpha, String startTime, String endTime)
temporalPageRank(double alpha, String startTime)
```

- Added the `temporalPageRank` traversal symbol so the step is represented in Gremlin bytecode.

- Registered the new symbol in `BytecodeHelper`, which allows bytecode-based traversal processing to recognize the new step.

### Supporting runtime changes

- Updated `TinkerGraphComputerView.legalEdge(...)` to safely handle cases where a vertex has no recorded legal edges after filtering. Before this change it assumed a set always existed.

- Updated `ProcessComputerSuite` to register temporal PageRank in the computer traversal suite wiring.
